### PR TITLE
Add missing productCard.businessLeasing translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wayke-se/components-react",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wayke-se/components-react",
-      "version": "4.6.4",
+      "version": "4.6.5",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.4.17",
@@ -10920,7 +10920,7 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayke-se/components-react",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "",
   "module": "dist/index.mjs",
   "main": "dist/index.js",

--- a/src/utils/I18n.ts
+++ b/src/utils/I18n.ts
@@ -239,6 +239,7 @@ export const initializeI18n = (marketCode: MarketCode = 'SE') => {
               productCard: {
                 price: 'Pris',
                 privateLeasing: 'Privatleasing',
+                businessLeasing: 'Företagsleasing',
               },
               search: {
                 filter: 'Filter',
@@ -535,6 +536,7 @@ export const initializeI18n = (marketCode: MarketCode = 'SE') => {
               productCard: {
                 price: 'Pris',
                 privateLeasing: 'Privatleasing',
+                businessLeasing: 'Bedriftsleasing',
               },
               search: {
                 filter: 'Filter',
@@ -832,6 +834,7 @@ export const initializeI18n = (marketCode: MarketCode = 'SE') => {
               productCard: {
                 price: 'Price',
                 privateLeasing: 'Privatleasing',
+                businessLeasing: 'Business leasing',
               },
               search: {
                 filter: 'Filter',


### PR DESCRIPTION
Intent: ProductCard rendered the raw key because no translation existed
  for productCard.businessLeasing in any locale (sv-SE, nb-NO, en-US).
Decision: Added a new key under productCard rather than reusing
  filter.attribute.businessLeasingPrice, mirroring the existing
  productCard.privateLeasing / filter.attribute.leasingPrice split so
  filter labels and price-card copy can diverge per context.

Bump version to 4.6.6.