### PR TITLE
Fix esbuild import syntax and align CI Node to 24

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,14 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node 22
+      - name: Use Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm (for OIDC trusted publishing)
-        run: npm install -g npm@latest
 
       - name: Cache dependencies
         id: cache

--- a/esbuild/lib.js
+++ b/esbuild/lib.js
@@ -2,7 +2,7 @@
 import * as esbuild from 'esbuild';
 import { copy } from 'esbuild-plugin-copy';
 import npmDts from 'npm-dts';
-import packageJson from '../package.json' assert { type: 'json' };
+import packageJson from '../package.json' with { type: 'json' };
 
 const Shared = {
   entryPoints: ['src/index.ts'],


### PR DESCRIPTION
Intent: The first OIDC-publish run failed because Node 22 hard-errors
  on the deprecated `assert { type: 'json' }` import attribute syntax
  in esbuild/lib.js. The same line emitted a deprecation warning on
  Node 18; bumping to 22 turned the warning into a build break.
Decision: Replace `assert` with the standardized `with` syntax (Stage 4
  import attributes), and bump CI Node 22 -> 24 so the runner matches
  the local dev version. Node 24 ships with npm 11.x natively, so the
  `npm install -g npm@latest` step is no longer needed and is removed.
Constraint: `with { type: 'json' }` requires Node >= 18.20 / 20.10 / 22+,
  so all currently-supported runtimes accept it.

Verified: `npm run build` passes locally on Node 24.