### PR TITLE
Fix repository.url org slug for provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wayke/components-react.git"
+    "url": "git+https://github.com/wayke-se/components-react.git"
   },
   "author": "Ourstudio",
   "license": "MIT",


### PR DESCRIPTION
Intent: Provenance-signed publish failed with HTTP 422 because the
  sigstore bundle (generated from github.repository = wayke-se/components-react)
  did not match package.json's repository.url which pointed to the legacy
  org slug `wayke` instead of `wayke-se`.
Decision: Update repository.url to the actual GitHub org so provenance
  verification succeeds. The mismatch was historical -- the repo was
  presumably renamed/moved years ago and the package.json field never
  followed. It went unnoticed until trusted publishing started enforcing
  it via the provenance bundle.