### PR TITLE
Use HttpLink for Apollo Client instantiation

### DIFF
--- a/src/providers/graphqlProvider.tsx
+++ b/src/providers/graphqlProvider.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
-import { ApolloProvider as ApolloProviderBase, ApolloClient, InMemoryCache } from '@apollo/client';
+import {
+  ApolloProvider as ApolloProviderBase,
+  ApolloClient,
+  InMemoryCache,
+  HttpLink,
+} from '@apollo/client';
 
 const GraphqlProvider = ({ uri, children }: { uri: string; children: React.ReactNode }) => {
-  const client = new ApolloClient({ uri, cache: new InMemoryCache() });
+  const client = new ApolloClient({
+    link: new HttpLink({ uri }),
+    cache: new InMemoryCache(),
+  });
   return <ApolloProviderBase client={client}>{children}</ApolloProviderBase>;
 };
 


### PR DESCRIPTION
Intent: Apollo Client 3.14 (picked up in the previous commit via the
  in-range minor bump from 3.13.1) started logging a runtime error when
  ApolloClient is constructed with `uri` directly. Without this fix,
  every consumer using GraphqlProvider would see Apollo error #17 in
  the console -- a regression we would otherwise ship in 4.6.7.
Decision: Switch to the documented form `new ApolloClient({ link: new
  HttpLink({ uri }), cache })`. Behavior is unchanged for callers; the
  client still talks to the same `uri`, but the link is now constructed
  explicitly as Apollo expects. Backwards-compatible with 3.13 too, so
  the change does not couple us to 3.14+.

Verified: typecheck + build pass, example app no longer logs the
  Apollo error in the browser console.